### PR TITLE
Update ban-enum.ts

### DIFF
--- a/ban-enum.ts
+++ b/ban-enum.ts
@@ -61,7 +61,6 @@ const banEnum: Deno.lint.Plugin = {
   rules: {
     'ban-enum': {
       create(ctx) {
-        console.log(ctx);
         return {
           TSEnumDeclaration(node) {
             ctx.report({


### PR DESCRIPTION
Removes the errant console.log line from the linting rule.